### PR TITLE
Support multiple ORDER BY properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ const q = query("SELECT * FROM c")
   - `udf` &lt;Object>
   - `maxItemCount` &lt;number> The number of items to return at a time
   - `continuation` &lt;Object> Continuation token
+  - `compositeIndexes `&lt;Object[][]> Optional composite index definitions for validating multiple `ORDER BY` properties. By default, no definition is required and this value is used only for validation.
 - Returns: &lt;Object>
   - `result` &lt;Object[]> Result documents
   - `continuation` &lt;Object> Continuation token for subsequent calls

--- a/src/continuation-token.ts
+++ b/src/continuation-token.ts
@@ -12,20 +12,24 @@ export type Token = {
   SRC?: number;
 
   // the value for the ORDER BY clause
-  RTD?: any;
+  RTD?: any[];
 };
 
-function encodeAny(RTD: any) {
+function encodeAnyArray(RTD: any[]) {
   return Buffer.from(JSON.stringify(RTD)).toString("base64");
 }
 
-function decodeAny(RTD: string) {
-  return JSON.parse(Buffer.from(RTD, "base64").toString());
+function decodeAnyArray(RTD: string) {
+  const v = JSON.parse(Buffer.from(RTD, "base64").toString());
+  if (!Array.isArray(v)) {
+    throw new TypeError("invalid RTS on continuation token");
+  }
+  return v;
 }
 
 export const encode = (t: Token) => {
   return `+RID:${t.RID}#RT:${t.RT}${t.SRC ? `#SRC:${t.SRC}` : ""}#TRC:${t.TRC}${
-    typeof t.RTD !== "undefined" ? `#RTD:${encodeAny(t.RTD)}` : ""
+    typeof t.RTD !== "undefined" ? `#RTD:${encodeAnyArray(t.RTD)}` : ""
   }`;
 };
 
@@ -45,7 +49,7 @@ export const decode = (token: string) => {
             value = parseInt(value, 10);
             break;
           case "RTD":
-            value = decodeAny(value);
+            value = decodeAnyArray(value);
             break;
           default:
           // noop

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,6 +1,8 @@
 import * as aggregateFunctions from "./aggregate-functions";
 import * as builtinFunctions from "./builtin-functions";
 import * as helpers from "./helpers";
+// eslint-disable-next-line no-unused-vars
+import { CompositeIndex } from "./types";
 
 export default (
   collection: any[],
@@ -9,7 +11,8 @@ export default (
     parameters,
     udf = {},
     maxItemCount,
-    continuation
+    continuation,
+    compositeIndexes
   }: {
     code: string;
     parameters?: {
@@ -23,6 +26,7 @@ export default (
     continuation?: {
       token: string;
     };
+    compositeIndexes?: CompositeIndex[][];
   }
 ) => {
   // eslint-disable-next-line no-new-func
@@ -41,6 +45,7 @@ export default (
     udf,
     params,
     maxItemCount,
-    continuation
+    continuation,
+    compositeIndexes
   );
 };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -65,7 +65,7 @@ const comparator = (a: any, b: any) => {
 };
 
 const getValue = (doc: any, [key, ...keys]: string[]): any => {
-  const value = doc ? doc[key] : undefined;
+  const value = typeof doc === "object" && doc ? doc[key] : undefined;
   if (keys.length && typeof value !== "undefined") {
     return getValue(value, keys);
   }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,6 +1,14 @@
 import * as continuationToken from "./continuation-token";
 
-const TYPE_ORDERS = new Set(["boolean", "null", "string", "number"]);
+const TYPE_ORDERS = new Set([
+  "undefined",
+  "null",
+  "boolean",
+  "number",
+  "string",
+  "array",
+  "object"
+]);
 
 const typeOf = (v: any) => {
   const t = typeof v;
@@ -41,7 +49,7 @@ const comparator = (a: any, b: any) => {
   const bType = typeOf(b);
 
   if (aType === bType) {
-    if (!TYPE_ORDERS.has(aType)) return 0;
+    if (aType === "object") return 0;
     return a < b ? -1 : 1;
   }
 
@@ -220,27 +228,10 @@ export const sort = (
     return comparator(rid1, rid2);
   });
 
-  if (!orders.length) return sorted;
+  if (orders.length !== 1) return sorted;
 
-  // find the index of the first invalid item (undefined, object or array)
-  let idx;
-  for (let i = sorted.length - 1; i >= 0; i -= 1) {
-    const doc = sorted[i];
-
-    for (let j = 0, l = orders.length; j < l; j += 1) {
-      const [getValue] = orders[j];
-      const value = getValue(doc);
-      const t = typeOf(value);
-      if (TYPE_ORDERS.has(t)) {
-        idx = i !== sorted.length - 1 ? i + 1 : -1;
-        break;
-      }
-    }
-
-    if (idx != null) break;
-  }
-
-  return idx != null && idx >= 0 ? sorted.slice(0, idx) : sorted;
+  const [getValue] = orders[0];
+  return sorted.filter(d => typeof getValue(d) !== "undefined");
 };
 
 export const paginate = (

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,6 @@
 import * as continuationToken from "./continuation-token";
+// eslint-disable-next-line no-unused-vars
+import { CompositeIndex } from "./types";
 
 const TYPE_ORDERS = new Set([
   "undefined",
@@ -60,6 +62,14 @@ const comparator = (a: any, b: any) => {
   }
 
   return 0;
+};
+
+const getValue = (doc: any, [key, ...keys]: string[]): any => {
+  const value = doc ? doc[key] : undefined;
+  if (keys.length && typeof value !== "undefined") {
+    return getValue(value, keys);
+  }
+  return value;
 };
 
 export const stripUndefined = (obj: any): any => {
@@ -211,13 +221,33 @@ export const sort = (
     [x: string]: any;
   }[],
   getRid: (a: any) => any,
-  ...orders: [(a: any) => any, boolean][]
+  compositeIndexes?: CompositeIndex[][],
+  ...orders: [any[], boolean][]
 ) => {
+  if (orders.length > 1 && compositeIndexes) {
+    const found = compositeIndexes.some(indexes => {
+      if (indexes.length !== orders.length) return false;
+
+      return indexes.every((index, i) => {
+        const [keys, desc] = orders[i];
+        const path = `/${keys.slice(1).join("/")}`;
+        const order = desc ? "descending" : "ascending";
+        return path === index.path && order === index.order;
+      });
+    });
+
+    if (!found) {
+      throw new Error(
+        "The order by query does not have a corresponding composite index that it can be served from."
+      );
+    }
+  }
+
   const sorted = collection.slice().sort((a, b) => {
     for (let i = 0, l = orders.length; i < l; i += 1) {
-      const [getValue, desc] = orders[i];
-      const aValue = getValue(a);
-      const bValue = getValue(b);
+      const [keys, desc] = orders[i];
+      const aValue = getValue(a, keys);
+      const bValue = getValue(b, keys);
       const r = comparator(aValue, bValue);
       if (r !== 0) return desc ? -r : r;
     }
@@ -230,8 +260,8 @@ export const sort = (
 
   if (orders.length !== 1) return sorted;
 
-  const [getValue] = orders[0];
-  return sorted.filter(d => typeof getValue(d) !== "undefined");
+  const [keys] = orders[0];
+  return sorted.filter(d => typeof getValue(d, keys) !== "undefined");
 };
 
 export const paginate = (
@@ -239,7 +269,7 @@ export const paginate = (
   maxItemCount?: number,
   continuation?: { token: string },
   getRid?: (a: any) => any,
-  ...orders: [(a: any) => any, boolean][]
+  ...orders: [any[], boolean][]
 ) => {
   let result = collection;
   let token: continuationToken.Token;
@@ -252,8 +282,8 @@ export const paginate = (
     let index = result.findIndex(([, d]) => {
       if (typeof token.RTD !== "undefined" && orders.length) {
         for (let i = 0, l = orders.length; i < l; i += 1) {
-          const [getValue, desc] = orders[i];
-          const rtd = getValue(d);
+          const [keys, desc] = orders[i];
+          const rtd = getValue(d, keys);
           const r = comparator(rtd, token.RTD[i]) * (desc ? -1 : 1);
           if (r < 0) return false;
           if (r > 0) return true;
@@ -294,7 +324,7 @@ export const paginate = (
       const RT = (token ? token.RT : 0) + 1;
       const TRC = (token ? token.TRC : 0) + maxItemCount;
       const RTD = orders.length
-        ? orders.map(([getValue]) => getValue(item))
+        ? orders.map(([keys]) => getValue(item, keys))
         : undefined;
 
       // calculate "SRC" which is the offset of items with the same `_rid`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import containsPartitionKeys from "./contains-partition-keys";
 import execute from "./executor";
 import { parse, SyntaxError } from "./parser"; // eslint-disable-line import/no-unresolved
 import transform from "./transformer";
+import { CompositeIndex } from "./types";
 
 class Query {
   _query: string;
@@ -35,7 +36,8 @@ class Query {
       parameters,
       udf,
       maxItemCount,
-      continuation
+      continuation,
+      compositeIndexes
     }: {
       parameters?: {
         name: string;
@@ -48,6 +50,7 @@ class Query {
       continuation?: {
         token: string;
       };
+      compositeIndexes?: CompositeIndex[][];
     } = {}
   ) {
     const { code } = this;
@@ -55,7 +58,14 @@ class Query {
       throw new Error("Missing code");
     }
 
-    return execute(coll, { code, parameters, udf, maxItemCount, continuation });
+    return execute(coll, {
+      code,
+      parameters,
+      udf,
+      maxItemCount,
+      continuation,
+      compositeIndexes
+    });
   }
 
   containsPartitionKeys(paths: string[]) {
@@ -64,4 +74,4 @@ class Query {
 }
 
 export default (query: string) => new Query(query);
-export { SyntaxError };
+export { CompositeIndex, SyntaxError };

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -8,7 +8,7 @@ type Context = {
   ast?: any;
   highCardinality?: boolean;
   document?: any;
-  orderBy?: any;
+  orderBy?: any[];
 };
 
 function transform(contexts: Context[], node: { [x: string]: any }) {
@@ -1010,16 +1010,15 @@ const definitions: { [key: string]: Function } = {
     contexts: Context[],
     { expressions }: { expressions: any[] }
   ) {
-    if (expressions.length > 1) {
-      throw new SyntaxError(
-        "Multiple order-by items are not supported. Please specify a single order-by items."
-      );
-    }
-
     const ctx = contexts[contexts.length - 1];
-    ctx.orderBy = transform(contexts, expressions[0]);
+    ctx.orderBy = expressions.map(e => transform(contexts, e));
 
-    return callHelperNode("sort", ctx.ast, ridPathNode(ctx), ctx.orderBy);
+    return callHelperNode(
+      "sort",
+      ctx.ast,
+      ridPathNode(ctx),
+      ...(ctx.orderBy || [])
+    );
   },
 
   sort_expression(
@@ -1092,7 +1091,7 @@ const definitions: { [key: string]: Function } = {
         { type: "Identifier", name: "$maxItemCount" },
         { type: "Identifier", name: "$continuation" },
         ridPathNode(ctx),
-        ctx.orderBy
+        ...(ctx.orderBy || [])
       );
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+export type CompositeIndex = {
+  path: string;
+  order: "ascending" | "descending";
+};

--- a/test/errors.ts
+++ b/test/errors.ts
@@ -46,7 +46,7 @@ export const cardinalityOfScalarSubqueryResultSetCannotBeGreaterThenOne = testQu
 export const multipleOrderByWithoutCompositeIndexes = testQuery(
   [],
   {
-    query: "SELECT c.id FROM c ORDER BY c.a, c.b",
+    query: "SELECT c.id FROM c ORDER BY c.a, c.b DESC",
     compositeIndexes: []
   },
   new Error(
@@ -70,7 +70,7 @@ export const multipleOrderByWithoutCorrespondingCompositeIndexes1 = testQuery(
 export const multipleOrderByWithoutCorrespondingCompositeIndexes2 = testQuery(
   [],
   {
-    query: "SELECT c.id FROM c ORDER BY c.a, c.b",
+    query: "SELECT c.id FROM c ORDER BY c.a, c.b DESC",
     compositeIndexes: [
       [{ path: "/b", order: "descending" }, { path: "/a", order: "ascending" }]
     ]

--- a/test/errors.ts
+++ b/test/errors.ts
@@ -42,3 +42,40 @@ export const cardinalityOfScalarSubqueryResultSetCannotBeGreaterThenOne = testQu
     "The cardinality of a scalar subquery result set cannot be greater than one."
   )
 );
+
+export const multipleOrderByWithoutCompositeIndexes = testQuery(
+  [],
+  {
+    query: "SELECT c.id FROM c ORDER BY c.a, c.b",
+    compositeIndexes: []
+  },
+  new Error(
+    "The order by query does not have a corresponding composite index that it can be served from."
+  )
+);
+
+export const multipleOrderByWithoutCorrespondingCompositeIndexes1 = testQuery(
+  [],
+  {
+    query: "SELECT c.id FROM c ORDER BY c.a, c.b DESC",
+    compositeIndexes: [
+      [{ path: "/a", order: "ascending" }, { path: "/b", order: "ascending" }]
+    ]
+  },
+  new Error(
+    "The order by query does not have a corresponding composite index that it can be served from."
+  )
+);
+
+export const multipleOrderByWithoutCorrespondingCompositeIndexes2 = testQuery(
+  [],
+  {
+    query: "SELECT c.id FROM c ORDER BY c.a, c.b",
+    compositeIndexes: [
+      [{ path: "/b", order: "descending" }, { path: "/a", order: "ascending" }]
+    ]
+  },
+  new Error(
+    "The order by query does not have a corresponding composite index that it can be served from."
+  )
+);

--- a/test/errors.ts
+++ b/test/errors.ts
@@ -17,16 +17,6 @@ export const reserved = testQuery(
   SyntaxError
 );
 
-export const multipleOrderByItems = testQuery(
-  [],
-  {
-    query: "select c.id from c order by c.a, c.b"
-  },
-  new SyntaxError(
-    "Multiple order-by items are not supported. Please specify a single order-by items."
-  )
-);
-
 export const asteriskIsOnlyValidWithSingleInputSet = testQuery(
   [],
   {

--- a/test/index.ts
+++ b/test/index.ts
@@ -517,6 +517,27 @@ export const orderByClause2 = testQuery(
   ]
 );
 
+export const orderByClause3 = testQuery(
+  collection,
+  {
+    query: `
+      SELECT f.id, f.creationDate
+      FROM Families f
+      ORDER BY f.address.city ASC, f.creationDate DESC
+    `
+  },
+  [
+    {
+      id: "WakefieldFamily",
+      creationDate: 1431620462
+    },
+    {
+      id: "AndersenFamily",
+      creationDate: 1431620472
+    }
+  ]
+);
+
 export const iteration1 = testQuery(
   collection,
   { query: "SELECT * FROM c IN Families.children" },

--- a/test/misc.ts
+++ b/test/misc.ts
@@ -749,6 +749,54 @@ export const multipleOrderBy = testQuery(
   ]
 );
 
+export const multipleOrderByWithCompositeIndexes = testQuery(
+  [
+    { id: "id1", sortKey1: "a", sortKey2: "a" },
+    { id: "id2", sortKey1: "a", sortKey2: "b" },
+    { id: "id3", sortKey1: "b", sortKey2: "a" },
+    { id: "id4", sortKey1: "b", sortKey2: "b" }
+  ],
+  {
+    query: "select * from c order by c.sortKey1, c.sortKey2 DESC",
+    compositeIndexes: [
+      [
+        { path: "/sortKey1", order: "ascending" },
+        { path: "/sortKey2", order: "descending" }
+      ]
+    ]
+  },
+  [
+    { id: "id2", sortKey1: "a", sortKey2: "b" },
+    { id: "id1", sortKey1: "a", sortKey2: "a" },
+    { id: "id4", sortKey1: "b", sortKey2: "b" },
+    { id: "id3", sortKey1: "b", sortKey2: "a" }
+  ]
+);
+
+export const multipleOrderByWithCompositeIndexes2 = testQuery(
+  [
+    { id: "id1", prop: { sortKey1: "a", sortKey2: "a" } },
+    { id: "id2", prop: { sortKey1: "a", sortKey2: "b" } },
+    { id: "id3", prop: { sortKey1: "b", sortKey2: "a" } },
+    { id: "id4", prop: { sortKey1: "b", sortKey2: "b" } }
+  ],
+  {
+    query: "select * from c order by c.prop.sortKey1 DESC, c.prop.sortKey2",
+    compositeIndexes: [
+      [
+        { path: "/prop/sortKey1", order: "descending" },
+        { path: "/prop/sortKey2", order: "ascending" }
+      ]
+    ]
+  },
+  [
+    { id: "id3", prop: { sortKey1: "b", sortKey2: "a" } },
+    { id: "id4", prop: { sortKey1: "b", sortKey2: "b" } },
+    { id: "id1", prop: { sortKey1: "a", sortKey2: "a" } },
+    { id: "id2", prop: { sortKey1: "a", sortKey2: "b" } }
+  ]
+);
+
 export const filterUndefinedOrderBy = testQuery(
   [{ id: "foo", sortKey: "a" }, { id: "bar" }, { id: "baz", sortKey: "b" }],
   {

--- a/test/misc.ts
+++ b/test/misc.ts
@@ -470,9 +470,14 @@ export const orderTypes = testQuery(
     query: "select value c.v from c order by c.v"
   },
   [
+    null,
     false,
     true,
-    null,
+    0,
+    0.5,
+    1,
+    2,
+    10,
     "01",
     "1",
     "10",
@@ -481,11 +486,12 @@ export const orderTypes = testQuery(
     "B",
     "a",
     "b",
-    0,
-    0.5,
-    1,
-    2,
-    10
+    [],
+    [1],
+    [2],
+    {},
+    { hi: 2 },
+    { hi: 1 }
   ]
 );
 
@@ -740,5 +746,31 @@ export const multipleOrderBy = testQuery(
     { id: "id1", sortKey1: "a", sortKey2: "a" },
     { id: "id4", sortKey1: "b", sortKey2: "b" },
     { id: "id3", sortKey1: "b", sortKey2: "a" }
+  ]
+);
+
+export const filterUndefinedOrderBy = testQuery(
+  [{ id: "foo", sortKey: "a" }, { id: "bar" }, { id: "baz", sortKey: "b" }],
+  {
+    query: "SELECT * FROM c ORDER BY c.sortKey"
+  },
+  [{ id: "foo", sortKey: "a" }, { id: "baz", sortKey: "b" }]
+);
+
+export const DoNotfilterUndefinedMultipleOrderBy = testQuery(
+  [
+    { id: "id1", sortKey1: "a", sortKey2: "a" },
+    { id: "id2", sortKey1: "b" },
+    { id: "id3", sortKey2: "b" },
+    { id: "id4" }
+  ],
+  {
+    query: "SELECT * FROM c ORDER BY c.sortKey1, c.sortKey2 DESC"
+  },
+  [
+    { id: "id3", sortKey2: "b" },
+    { id: "id4" },
+    { id: "id1", sortKey1: "a", sortKey2: "a" },
+    { id: "id2", sortKey1: "b" }
   ]
 );

--- a/test/misc.ts
+++ b/test/misc.ts
@@ -724,3 +724,21 @@ export const notEqualDifferentType = testQuery(
   },
   [{ id: "javi", foo: null }]
 );
+
+export const multipleOrderBy = testQuery(
+  [
+    { id: "id1", sortKey1: "a", sortKey2: "a" },
+    { id: "id2", sortKey1: "a", sortKey2: "b" },
+    { id: "id3", sortKey1: "b", sortKey2: "a" },
+    { id: "id4", sortKey1: "b", sortKey2: "b" }
+  ],
+  {
+    query: "select * from c order by c.sortKey1, c.sortKey2 DESC"
+  },
+  [
+    { id: "id2", sortKey1: "a", sortKey2: "b" },
+    { id: "id1", sortKey1: "a", sortKey2: "a" },
+    { id: "id4", sortKey1: "b", sortKey2: "b" },
+    { id: "id3", sortKey1: "b", sortKey2: "a" }
+  ]
+);

--- a/test/utils/test-query.ts
+++ b/test/utils/test-query.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
-import query from "../../lib";
+// eslint-disable-next-line no-unused-vars
+import query, { CompositeIndex } from "../../lib";
 
 export default (
   collection: any[] | undefined | null,
@@ -12,6 +13,7 @@ export default (
     udf?: {
       [x: string]: any;
     };
+    compositeIndexes?: CompositeIndex[][];
   },
   expected:
     | any
@@ -22,7 +24,8 @@ export default (
 ) => () => {
   const opts = {
     parameters: params.parameters,
-    udf: params.udf
+    udf: params.udf,
+    compositeIndexes: params.compositeIndexes
   };
 
   if (expected instanceof Error || expected.prototype instanceof Error) {


### PR DESCRIPTION
As the title 

- [x] Add validations with composite indexes
- [x] Allow to sort by `undefined` when multiple `ORDER BY` are used

> If your Order By query uses a composite index, the results will always include documents with an undefined sort property in the query results.

https://docs.microsoft.com/en-us/azure/cosmos-db/sql-query-order-by#documents-with-missing-fields 