### PR TITLE
Obtaining partition key from value

### DIFF
--- a/src/contains-partition-keys.ts
+++ b/src/contains-partition-keys.ts
@@ -20,7 +20,7 @@ function conditionKeyNodes(node: { [x: string]: any }): any[] {
 
 function toPartitionKey(node: { [x: string]: any }): string | null {
   if (node.type === "scalar_member_expression") {
-    return `${toPartitionKey(node.object) || ""}/${node.property.name}`;
+    return `${toPartitionKey(node.object) || ""}/${node.property.name || node.property.value}`;
   }
   return null;
 }


### PR DESCRIPTION
I may have this wrong, as new to Cosmos DB.   Thank you for putting this emulator together, as I run everything Linux.  I've been using the Java client to work with this emulator successfully, however can't get the readAllItems(partitionKey) to work.

The above I believe is the fix, as there is no name attribute being provided.

However, if something in the Java client I'm missing, happy to ignore this - though let me know what might be.

Again, many thanks for putting this together.